### PR TITLE
Another quick fix for Japanese R/S

### DIFF
--- a/_site/functions.js
+++ b/_site/functions.js
@@ -12,7 +12,7 @@ const START_DATA = {
     "FRLG": {start: "0x02029314", has_aslr: true},
     "RS": {start: "0x020300A0", has_aslr: false},
     "Emerald-JP": {start: "0x020294AC", has_aslr: true},
-    "FRLG-JP": {start: "0x0x0202924C", has_aslr: true},
+    "FRLG-JP": {start: "0x0202924C", has_aslr: true},
     "RS-JP": {start: "0x0202FDBC", has_aslr: false}
 };
 

--- a/_site/functions.js
+++ b/_site/functions.js
@@ -202,7 +202,7 @@ function parseWhichBoxFormData(data) {
     result.start &= ADDRESS_MASK;
     result.offset &= ADDRESS_MASK;
     result.diff = result.offset - result.start;
-    if(result.game != "RS") {
+    if(result.game != "RS" && result.game != "RS-JP") {
         result.full_range = !!data.get("full-range")
         if(result.full_range) {
             validateFormDiff(result.diff_end = result.diff);


### PR DESCRIPTION
I forgot about this `if` condition, and that caused the Japanese R/S address to be incorrectly calculated with an ASLR offset of 124 which is not possible in any R/S game as far as I know.